### PR TITLE
Update Pullable.js

### DIFF
--- a/Pullable.js
+++ b/Pullable.js
@@ -217,19 +217,21 @@ export default class extends Component {
     make changes directly to a component without using state/props to trigger a re-render of the entire subtree
     */
     defaultTopIndicatorRender(pulling, pullok, pullrelease, gesturePosition) {
-        if (pulling) {
-            this.txtPulling && this.txtPulling.setNativeProps({style: styles.show});
-            this.txtPullok && this.txtPullok.setNativeProps({style: styles.hide});
-            this.txtPullrelease && this.txtPullrelease.setNativeProps({style: styles.hide});
-        } else if (pullok) {
-            this.txtPulling && this.txtPulling.setNativeProps({style: styles.hide});
-            this.txtPullok && this.txtPullok.setNativeProps({style: styles.show});
-            this.txtPullrelease && this.txtPullrelease.setNativeProps({style: styles.hide});
-        } else if (pullrelease) {
-            this.txtPulling && this.txtPulling.setNativeProps({style: styles.hide});
-            this.txtPullok && this.txtPullok.setNativeProps({style: styles.hide});
-            this.txtPullrelease && this.txtPullrelease.setNativeProps({style: styles.show});
-        }
+        setTimeout(() => {
+            if (pulling) {
+                this.txtPulling && this.txtPulling.setNativeProps({style: styles.show});
+                this.txtPullok && this.txtPullok.setNativeProps({style: styles.hide});
+                this.txtPullrelease && this.txtPullrelease.setNativeProps({style: styles.hide});
+            } else if (pullok) {
+                this.txtPulling && this.txtPulling.setNativeProps({style: styles.hide});
+                this.txtPullok && this.txtPullok.setNativeProps({style: styles.show});
+                this.txtPullrelease && this.txtPullrelease.setNativeProps({style: styles.hide});
+            } else if (pullrelease) {
+                this.txtPulling && this.txtPulling.setNativeProps({style: styles.hide});
+                this.txtPullok && this.txtPullok.setNativeProps({style: styles.hide});
+                this.txtPullrelease && this.txtPullrelease.setNativeProps({style: styles.show});
+            }
+        }, 1);
         return (
             <View style={{flexDirection: 'row', justifyContent: 'center', alignItems: 'center', height: defaultTopIndicatorHeight}}>
                 <ActivityIndicator size="small" color="gray" />


### PR DESCRIPTION
目前遇到了一个需求，就是在下拉刷新的时候禁用掉其他组件的滑动事件，所以在`onPulling` 事件中去禁用其他组件的滑动事件
本人用的是这个组件 [https://github.com/skv-headless/react-native-scrollable-tab-view](https://github.com/skv-headless/react-native-scrollable-tab-view)
因为`scrollable-tab-view`是作为`pulllist`组件的父级存在的，所以在修改了state后触发了重绘`render`
在`render`方法中调用了`defaultTopIndicatorRender` 而这时由于组件已经重绘，所以 `txtPulling/txtPullok/txtPullrelease`三个的引用实际上已经不存在了，调用`setNativeProps`方法会获得一个警告
`
Warning: _class is accessing findNodeHandle inside its render(). render() should be a pure function of props and state. It should never access something that requires stale data from the previous render, such as refs. Move this logic to componentDidMount and componentDidUpdate instead.
`
so,添加一个小小的延迟，先让组件渲染完毕，然后判断组件当前的状态`pulling pullok pullrelease` 进行`setNativeProps`
😄